### PR TITLE
Replace <curl-easy> finalization with macro

### DIFF
--- a/documentation/source/introduction.rst
+++ b/documentation/source/introduction.rst
@@ -46,9 +46,11 @@ wrapper, you create an object of the :class:`<curl-easy>` class.
 .. code-block:: dylan
    :caption: Dylan example
 
-   let curl = make(<curl-easy>);
+   with-curl-easy (curl)
+     ...
+   end;
 
-The :class:`<curl-easy>` object handles both initialization and
+The macro :macro:`with-curl-easy` handles both initialization and
 automatic cleanup when it is no longer accessible. If initialization
 fails, a :class:`<curl-init-error>` exception is raised.
 
@@ -59,7 +61,7 @@ In libcurl, parameters are configured using `curl_easy_setopt
 <https://curl.se/libcurl/c/curl_easy_setopt.html>`_, where a constant
 representing the option name is paired with its value. In the Open
 Dylan wrapper, options are set directly using property syntax, such as
-``curl.curl-option-name := value`. If an error occurs while setting a
+``curl.curl-option-name := value``. If an error occurs while setting a
 parameter, a :class:`<curl-option-error>` exception is raised.
 
 .. code-block:: c
@@ -87,8 +89,9 @@ to another method for centralized error handling.
 .. code-block:: dylan
    :caption: In Dylan errors can be captured in a block somewhere.
 
-   let curl = make(<curl-easy>);
-   curl.curl-url := "https://example.com";
+   with-curl-easy (curl)
+     curl.curl-url := "https://example.com";
+   end;
 
    ...
 
@@ -132,7 +135,7 @@ In Opendylan :function:`curl-perform` raises a
 Retrieving Information
 ^^^^^^^^^^^^^^^^^^^^^^
 
-In libcurl, retrieving information is done with ``curl_easy_getinfo`,
+In libcurl, retrieving information is done with ``curl_easy_getinfo``,
 passing a constant for the type of information. In the Open Dylan
 wrapper, you access the information directly using property syntax.
 
@@ -163,10 +166,11 @@ wrapper, you access the information directly using property syntax.
    :caption: Dylan Example
 
    block ()
-      let curl = make(<curl-easy>);
-      curl.curl-url := "https://example.com/";
-      curl-easy-perform(curl);
-      format-out("Time: %d", curl.total-time);
+      with-curl-easy (curl)
+        curl.curl-url := "https://example.com/";
+        curl-easy-perform(curl);
+        format-out("Time: %d", curl.total-time)
+      end
    exception (err :: <curl-info-error>)
       format-err("curl easy getinfo failed: %s\n",
                  err.curl-error-message)

--- a/src/curl-easy-module.dylan
+++ b/src/curl-easy-module.dylan
@@ -301,7 +301,8 @@ define module curl-easy
 
   create
     <curl>,
-    <curl-easy>;
+    <curl-easy>,
+    with-curl-easy;
 
   create
     c-curl-easy-header,
@@ -729,6 +730,5 @@ define module curl-easy-impl
   use curl-easy;
 
   use common-dylan;
-  use finalization;
   use c-ffi;
 end module;

--- a/tests/test-get-simple-http-page.dylan
+++ b/tests/test-get-simple-http-page.dylan
@@ -7,11 +7,12 @@ Copyright: Copyright (C) 2025, Dylan Hackers. All rights reserved.
 define test test-get-simple-http-page (tags: #("io"))
   block ()
     curl-global-init($curl-global-default);
-    let curl = make(<curl-easy>);
-    curl.curl-url := "https://example.com/";
-    curl.curl-followlocation := 1;
-    curl-easy-perform(curl);
-    assert-true(#t);
+    with-curl-easy (curl)
+      curl.curl-url := "https://example.com/";
+      curl.curl-followlocation := 1;
+      curl-easy-perform(curl);
+      assert-true(#t);
+    end;
   cleanup
     curl-global-cleanup();
   exception (err :: <curl-error>)

--- a/tests/test-getinfo-cainfo.dylan
+++ b/tests/test-getinfo-cainfo.dylan
@@ -5,11 +5,12 @@ Copyright: Copyright (C) 2025, Dylan Hackers. All rights reserved.
 define test test-getinfo-cainfo ()
   curl-global-init($curl-global-default);
   block ()
-    let curl = make(<curl-easy>);
-    curl.curl-cainfo := "/etc/ssl/certs/SecureTrust_CA.pem";
-    let cainfo = curl.curl-cainfo;
-    format-out("default ca info path: '%s'\n", cainfo);
-    assert-true(#t);
+    with-curl-easy (curl)
+      curl.curl-cainfo := "/etc/ssl/certs/SecureTrust_CA.pem";
+      let cainfo = curl.curl-cainfo;
+      format-out("default ca info path: '%s'\n", cainfo);
+      assert-true(#t);
+    end;
   cleanup
     curl-global-cleanup();
   exception (err :: <curl-error>)

--- a/tests/test-httpbin.dylan
+++ b/tests/test-httpbin.dylan
@@ -5,11 +5,12 @@ License:    See License.txt in this distribution for details.
 define test test-postfields (tags: #("io"))
   block()
     curl-global-init($curl-global-default);
-    let curl = make(<curl-easy>);
-    curl.curl-url := httpbin("/post");
-    curl.curl-postfields := "name=daniel&project=curl";
-    curl-easy-perform(curl);
-    assert-equal(200, curl.curl-response-code);
+    with-curl-easy (curl)
+      curl.curl-url := httpbin("/post");
+      curl.curl-postfields := "name=daniel&project=curl";
+      curl-easy-perform(curl);
+      assert-equal(200, curl.curl-response-code);
+    end with-curl-easy;
   cleanup
     curl-global-cleanup();
   end block;
@@ -18,14 +19,15 @@ end test;
 define test test-http-methods (tags: #("io", "httpbin"))
   block ()
     curl-global-init($curl-global-default);
-    let curl = make(<curl-easy>);
-    let http-methods = list("delete", "get", "patch", "post", "put");
-    for (http-method in http-methods)
-      curl.curl-url := concatenate(httpbin("/"), http-method);
-      curl.curl-customrequest := uppercase(http-method);
-      curl-easy-perform(curl);
-      assert-equal(200, curl.curl-response-code);
-    end for;
+    with-curl-easy (curl)
+      let http-methods = list("delete", "get", "patch", "post", "put");
+      for (http-method in http-methods)
+        curl.curl-url := concatenate(httpbin("/"), http-method);
+        curl.curl-customrequest := uppercase(http-method);
+        curl-easy-perform(curl);
+        assert-equal(200, curl.curl-response-code);
+      end for;
+    end with-curl-easy;
   cleanup
     curl-global-cleanup();
   end block;
@@ -34,12 +36,13 @@ end test;
 define test test-auth-basic (tags: #("io", "httpbin"))
   block ()
     curl-global-init($curl-global-default);
-    let curl = make(<curl-easy>);
-    curl.curl-url := httpbin("/basic-auth/admin/hunter42");
-    curl.curl-username := "admin";
-    curl.curl-password := "hunter42";
-    curl.curl-easy-perform;
-    assert-equal(200, curl.curl-response-code);
+    with-curl-easy (curl)
+      curl.curl-url := httpbin("/basic-auth/admin/hunter42");
+      curl.curl-username := "admin";
+      curl.curl-password := "hunter42";
+      curl.curl-easy-perform;
+      assert-equal(200, curl.curl-response-code);
+    end with-curl-easy;
   cleanup
     curl-global-cleanup();
   end block;
@@ -49,13 +52,14 @@ define test test-auth-bearer (tags: #("io", "httpbin"))
   let headers = null-pointer(<curlopt-slistpoint>);
   block ()
     curl-global-init($curl-global-default);
-    let curl = make(<curl-easy>);
-    curl.curl-url := httpbin("/bearer");
-    let bearer = "hunter42";
-    headers := curl-slist-append(headers, concatenate("Authorization: Bearer ", bearer));
-    curl.curl-httpheader := headers;
-    curl-easy-perform(curl);
-    assert-equal(200, curl.curl-response-code);
+    with-curl-easy (curl)
+      curl.curl-url := httpbin("/bearer");
+      let bearer = "hunter42";
+      headers := curl-slist-append(headers, concatenate("Authorization: Bearer ", bearer));
+      curl.curl-httpheader := headers;
+      curl-easy-perform(curl);
+      assert-equal(200, curl.curl-response-code);
+    end with-curl-easy;      
   cleanup
     curl-slist-free-all(headers);
     curl-global-cleanup();
@@ -65,14 +69,15 @@ end test test-auth-bearer;
 define test test-auth-digest (tags: #("io", "httpbin"))
   block ()
     curl-global-init($curl-global-default);
-    let curl = make(<curl-easy>);
-    let url = httpbin("/digest-auth/auth/user/passwd");
-    curl.curl-url := url;
-    curl.curl-verbose := 0;
-    curl.curl-userpwd := "user:passwd";
-    curl.curl-httpauth := $curlauth-digest;
-    curl-easy-perform(curl);
-    assert-equal(200, curl.curl-response-code);
+    with-curl-easy (curl)
+      let url = httpbin("/digest-auth/auth/user/passwd");
+      curl.curl-url := url;
+      curl.curl-verbose := 0;
+      curl.curl-userpwd := "user:passwd";
+      curl.curl-httpauth := $curlauth-digest;
+      curl-easy-perform(curl);
+      assert-equal(200, curl.curl-response-code);
+    end with-curl-easy;
   cleanup
     curl-global-cleanup();
   end block;

--- a/tests/test-https.dylan
+++ b/tests/test-https.dylan
@@ -7,13 +7,14 @@ Reference:  https://curl.se/libcurl/c/https.html
 define test test-https (tags: #("io", "slow"))
   block ()
     curl-global-init($curl-global-default);
-    let curl = make(<curl-easy>);
-    curl.curl-url := "https://example.org";
-    curl.curl-ssl-verifypeer := 1;
-    curl.curl-ssl-verifyhost := 1;
-    curl.curl-ca-cache-timeout := 604800;
-    curl-easy-perform(curl);
-    assert-true(#t);
+    with-curl-easy (curl)
+      curl.curl-url := "https://example.org";
+      curl.curl-ssl-verifypeer := 1;
+      curl.curl-ssl-verifyhost := 1;
+      curl.curl-ca-cache-timeout := 604800;
+      curl-easy-perform(curl);
+      assert-true(#t);
+    end with-curl-easy;
   cleanup
     curl-global-cleanup();
   exception (err :: <curl-error>)

--- a/tests/test-option-headers.dylan
+++ b/tests/test-option-headers.dylan
@@ -7,14 +7,15 @@ define test test-option-headers (tags: #("io", "httpbin"))
   curl-global-init($curl-global-default);
   let headers = null-pointer(<curlopt-slistpoint>);
   block ()
-    let curl = make(<curl-easy>);
-    curl.curl-url := httpbin("/headers");
+    with-curl-easy (curl)
+      curl.curl-url := httpbin("/headers");
 
-    headers := curl-slist-append(headers, "X-Custom-Header: Chucho");
-    headers := curl-slist-append(headers, "Another-Header: Good");
-    curl.curl-httpheader := headers;
-    curl-easy-perform(curl);
-    assert-true(#t);
+      headers := curl-slist-append(headers, "X-Custom-Header: Chucho");
+      headers := curl-slist-append(headers, "Another-Header: Good");
+      curl.curl-httpheader := headers;
+      curl-easy-perform(curl);
+      assert-true(#t);
+    end with-curl-easy;
   cleanup
     curl-slist-free-all(headers);
     curl-global-cleanup();


### PR DESCRIPTION
Replace finalization with a macro that does the cleanup in a block.