### PR TITLE
Rewrite macro 'with-curl-easy'

### DIFF
--- a/documentation/source/reference.rst
+++ b/documentation/source/reference.rst
@@ -153,21 +153,35 @@ Macros
 
    :macrocall:
      .. parsed-literal::
-	with-curl-easy (*name*) body end
+        with-curl-easy (*variable* = *expression*, *option* = *value*, ...) body end
 
    :example:
 
      .. code-block:: dylan
+        :caption: Simple macro form
 
-        with-curl-easy (curl)
-          curl.url := "example.com";
-	  curl-easy-perform(curl);
-	end;
+        with-curl-easy (curl = make(<curl-easy>))
+          curl.curl-url := "http://example.com";
+          curl-easy-perform(curl);
+        end;
+
+   :example:
+    
+     .. code-block:: dylan
+        :caption: Passing options to macro
+
+        with-curl-easy (curl = make(<curl-easy>),
+                        url = "http://example.com",
+                        verbose = #t)
+          curl-easy-perform(curl);
+        end;
 
    :signals:
 
       :class:`<curl-init-error>` if the curl handle could not be
       initialized.
+
+      :class:`<curl-option-error>` if an option is incorrect.
 
    :discussion:
 
@@ -214,7 +228,7 @@ Macros
 
         with-curl-global ($curl-global-all)
           with-curl-easy (curl)
-            curl.url := "https://example.com";
+            curl.curl-url := "https://example.com";
             curl-easy-perform(curl);
 	    // do staff
           end;

--- a/src/curl-easy-module.dylan
+++ b/src/curl-easy-module.dylan
@@ -342,6 +342,8 @@ define module curl-easy
     $curl-progress-callback;
 
   // Curl options
+  create
+    *curl-options*;
 
   create
     <curlopt-stringpoint>,
@@ -731,9 +733,11 @@ end module curl-easy;
 
 define module curl-easy-impl
   use curl-easy;
-
+  
   use common-dylan;
   use c-ffi;
+  use format;
+  use format-out;
 
   export
     *curl-library-initialized?*;

--- a/src/library.dylan
+++ b/src/library.dylan
@@ -7,4 +7,5 @@ define library dylan-curl
   
   use common-dylan;
   use c-ffi;
+  use io;
 end library;

--- a/tests/test-chkspeed.dylan
+++ b/tests/test-chkspeed.dylan
@@ -19,19 +19,19 @@ define test test-chkspeed (tags: #("io", "slow"))
 	  0
 	end;
   let url = "http://ipv4.download.thinkbroadband.com";
+  let filename = "5MB.zip";
   block () 
     with-curl-global ($curl-global-default)
-      with-curl-easy (curl)
-	let filename = "5MB.zip";
-	curl.curl-url := concatenate(url, "/", filename);
-	curl.curl-useragent := "dylan-curl-speedchecker/1.0";
-	curl.curl-writefunction := $curl-write-callback;
-	curl.curl-xferinfofunction := $curl-progress-callback;
-	curl.curl-noprogress := #f;
-	with-open-file (stream = filename, direction: #"output", if-exists: #"replace")
-	  dynamic-bind(*curl-write-callback* = handle-download)
-	    dynamic-bind(*curl-progress-callback* = progress-callback)
-	      register-c-dylan-object(stream);
+      with-curl-easy (curl = make(<curl-easy>),
+	                    url = concatenate(url, "/", filename),
+	                    useragent = "dylan-curl-speedchecker/1.0",
+	                    writefunction = $curl-write-callback,
+	                    xferinfofunction = $curl-progress-callback,
+	                    noprogress = #f)
+	      with-open-file (stream = filename, direction: #"output", if-exists: #"replace")
+	        dynamic-bind(*curl-write-callback* = handle-download)
+	          dynamic-bind(*curl-progress-callback* = progress-callback)
+	            register-c-dylan-object(stream);
               curl.curl-writedata := export-c-dylan-object(stream);
               curl-easy-perform(curl);
               unregister-c-dylan-object(stream);

--- a/tests/test-debug-callback.dylan
+++ b/tests/test-debug-callback.dylan
@@ -36,12 +36,12 @@ end function;
 define test test-debug-callback (tags: #("io"))
   block ()
     with-curl-global ($curl-global-default)
-      with-curl-easy (curl)
+      with-curl-easy (curl = make(<curl-easy>),
+	                    url = "https://example.com/",
+	                    verbose = #t,  // verbose to use debug-callback
+	                    debugfunction = $curl-debug-callback)
         dynamic-bind (*curl-debug-callback* = dump-debug-callback)
-	  curl.curl-url := "https://example.com/";
-          curl.curl-verbose := #t;  // verbose to use debug-callback
-          curl.curl-debugfunction := $curl-debug-callback;
-          curl-easy-perform(curl);
+	        curl-easy-perform(curl);
         end dynamic-bind;
         assert-true(#t);
       end with-curl-easy;

--- a/tests/test-escape-unescape.dylan
+++ b/tests/test-escape-unescape.dylan
@@ -4,7 +4,7 @@ Copyright: Copyright (C) 2025, Dylan Hackers. All rights reserved.
 
 define test test-curl-easy-escape ()
   with-curl-global ($curl-global-default)
-    with-curl-easy (curl)
+    with-curl-easy (curl = make(<curl-easy>))
       let data = "data to convert";
       let expected = "data%20to%20convert";
       let output1 = curl-easy-escape(curl, data, length: 15);
@@ -17,18 +17,18 @@ end test;
 
 define test test-curl-easy-unescape () 
   with-curl-global ($curl-global-default)
-    with-curl-easy (curl)
+    with-curl-easy (curl = make(<curl-easy>))
       let escaped = "%63%75%72%6c";
       let expected = "curl";
       let expected-length = 4;
       let (decoded, decoded-length)
-	= curl-easy-unescape(curl, escaped, length: 12);
+	      = curl-easy-unescape(curl, escaped, length: 12);
       assert-equal(expected, decoded,
 		   "Decoded string is as expected");
       assert-equal(expected-length, decoded-length,
 		   "Decoded length is as expected");
       let (decoded, decoded-length)
-	= curl-easy-unescape(curl, escaped);
+	      = curl-easy-unescape(curl, escaped);
       assert-equal(expected, decoded);
       assert-equal(expected-length, decoded-length);
     end with-curl-easy;

--- a/tests/test-get-simple-http-page.dylan
+++ b/tests/test-get-simple-http-page.dylan
@@ -6,14 +6,14 @@ Copyright: Copyright (C) 2025, Dylan Hackers. All rights reserved.
 
 define test test-get-simple-http-page (tags: #("io"))
   block ()
-    with-curl-global($curl-global-default)
-      with-curl-easy (curl)
-	curl.curl-url := "https://example.com/";
-	curl.curl-followlocation := 1;
-	curl-easy-perform(curl);
-	assert-true(#t);
-      end;
-    end;
+    with-curl-global ($curl-global-default)
+      with-curl-easy (curl = make(<curl-easy>),
+                      url = "https://example.com",
+                      followlocation = 1)
+	      curl-easy-perform(curl);
+	      assert-true(#t);
+      end with-curl-easy;
+    end with-curl-global;
   exception (err :: <curl-error>)
     format-out("Curl failed: %s\n", err.curl-error-message);
   end block;

--- a/tests/test-getinfo-cainfo.dylan
+++ b/tests/test-getinfo-cainfo.dylan
@@ -5,11 +5,11 @@ Copyright: Copyright (C) 2025, Dylan Hackers. All rights reserved.
 define test test-getinfo-cainfo () 
   block ()
     with-curl-global ($curl-global-default)
-      with-curl-easy (curl)
-	curl.curl-cainfo := "/etc/ssl/certs/SecureTrust_CA.pem";
-	let cainfo = curl.curl-cainfo;
-	format-out("default ca info path: '%s'\n", cainfo);
-	assert-true(#t);
+      with-curl-easy (curl = make(<curl-easy>),
+                      cainfo = "/etc/ssl/certs/SecureTrust_CA.pem")
+	      let cainfo = curl.curl-cainfo;
+	      format-out("default ca info path: '%s'\n", cainfo);
+	      assert-true(#t);
       end with-curl-easy;
     end with-curl-global;
   exception (err :: <curl-error>)

--- a/tests/test-httpbin.dylan
+++ b/tests/test-httpbin.dylan
@@ -16,16 +16,16 @@ define function httpbin
 end;
 
 define test test-postfields (tags: #("io"))
-  with-curl-easy (curl)
-    curl.curl-url := httpbin("/post");
-    curl.curl-postfields := "name=daniel&project=curl";
+  with-curl-easy (curl = make(<curl-easy>),
+                  url = httpbin("/post"),
+                  postfields = "name=daniel&project=curl")
     curl-easy-perform(curl);
     assert-equal(200, curl.curl-response-code);
   end with-curl-easy;
 end test;
 
 define test test-http-methods (tags: #("io", "httpbin"))
-  with-curl-easy (curl)
+  with-curl-easy (curl = make(<curl-easy>))
     let http-methods = list("delete", "get", "patch", "post", "put");
     for (http-method in http-methods)
       curl.curl-url := concatenate(httpbin("/"), http-method);
@@ -37,10 +37,10 @@ define test test-http-methods (tags: #("io", "httpbin"))
 end test;
 
 define test test-auth-basic (tags: #("io", "httpbin"))
-  with-curl-easy (curl)
-    curl.curl-url := httpbin("/basic-auth/admin/hunter42");
-    curl.curl-username := "admin";
-    curl.curl-password := "hunter42";
+  with-curl-easy (curl = make(<curl-easy>),
+                  url = httpbin("/basic-auth/admin/hunter42"),
+                  username = "admin",
+                  password = "hunter42")
     curl.curl-easy-perform;
     assert-equal(200, curl.curl-response-code);
   end with-curl-easy;
@@ -48,12 +48,12 @@ end test;
 
 define test test-auth-bearer (tags: #("io", "httpbin"))
   let headers = null-pointer(<curlopt-slistpoint>);
+  let bearer = "hunter42";
   block ()
-    with-curl-easy (curl)
-      curl.curl-url := httpbin("/bearer");
-      let bearer = "hunter42";
-      headers := curl-slist-append(headers, concatenate("Authorization: Bearer ", bearer));
-      curl.curl-httpheader := headers;
+    headers := curl-slist-append(headers, concatenate("Authorization: Bearer ", bearer));
+    with-curl-easy (curl = make(<curl-easy>),
+                    url = httpbin("/bearer"),
+	                  httpheader = headers)
       curl-easy-perform(curl);
       assert-equal(200, curl.curl-response-code);
     end with-curl-easy;      
@@ -63,12 +63,12 @@ define test test-auth-bearer (tags: #("io", "httpbin"))
 end test test-auth-bearer;
 
 define test test-auth-digest (tags: #("io", "httpbin"))
-  with-curl-easy (curl)
-    let url = httpbin("/digest-auth/auth/user/passwd");
-    curl.curl-url := url;
-    curl.curl-verbose := #f;
-    curl.curl-userpwd := "user:passwd";
-    curl.curl-httpauth := $curlauth-digest;
+  let url = httpbin("/digest-auth/auth/user/passwd");
+  with-curl-easy (curl = make(<curl-easy>),
+                  url = url,
+                  verbose = #f,
+                  userpwd = "user:passwd",
+                  httpauth = $curlauth-digest)
     curl-easy-perform(curl);
     assert-equal(200, curl.curl-response-code);
   end with-curl-easy;

--- a/tests/test-https.dylan
+++ b/tests/test-https.dylan
@@ -5,15 +5,15 @@ License:    See License.txt in this distribution for details.
 Reference:  https://curl.se/libcurl/c/https.html
 
 define test test-https (tags: #("io", "slow"))
-  block () 
+  block ()
     with-curl-global ($curl-global-default)
-      with-curl-easy (curl)
-	curl.curl-url := "https://example.org";
-	curl.curl-ssl-verifypeer := #f;
-	curl.curl-ssl-verifyhost := 1;
-	curl.curl-ca-cache-timeout := 604800;
-	curl-easy-perform(curl);
-	assert-true(#t);
+      with-curl-easy (curl = make(<curl-easy>),
+                      url = "https://example.org",
+                      ssl-verifypeer = #f,
+                      ssl-verifyhost = 1,
+                      ca-cache-timeout = 604800)
+        curl-easy-perform(curl);
+        assert-true(#t);
       end with-curl-easy;
     end with-curl-global;
   exception (err :: <curl-error>)

--- a/tests/test-option-headers.dylan
+++ b/tests/test-option-headers.dylan
@@ -5,12 +5,12 @@ License:    See License.txt in this distribution for details.
 
 define test test-option-headers (tags: #("io", "httpbin"))
   with-curl-global($curl-global-default)
-    with-curl-easy (curl)
-      curl.curl-url := httpbin("/headers");
-      let headers = null-pointer(<curlopt-slistpoint>);
-      headers := curl-slist-append(headers, "X-Custom-Header: Chucho");
-      headers := curl-slist-append(headers, "Another-Header: Good");
-      curl.curl-httpheader := headers;
+    let headers = null-pointer(<curlopt-slistpoint>);
+    headers := curl-slist-append(headers, "X-Custom-Header: Chucho");
+    headers := curl-slist-append(headers, "Another-Header: Good");
+    with-curl-easy (curl = make(<curl-easy>),
+                    url = httpbin("/headers"),
+                    httpheader = headers)
       curl-easy-perform(curl);
       curl-slist-free-all(headers);
       assert-true(#t);


### PR DESCRIPTION
Use a variable to initialize the curl handler, instead of creating the class inside the macro. This allows to subclass `<curl-easy>`.

```dylan
with-curl-easy(curl = make(<curl-easy>))
  curl.curl-url := "http://example.com";
  curl.curl-verbose := #f;
  curl-easy-perform(curl);
end;
```

Now is possible to pass options to the macro. It makes less verbose the code.

```dylan
with-curl-easy(curl = make(<curl-easy>),
               url = "http://example.com",
               verbose = #f)
  curl-easy-perform(curl)
end;
```

Closes #8