### PR TITLE
Rewrite 'with-easy-curl' macro

### DIFF
--- a/documentation/source/introduction.rst
+++ b/documentation/source/introduction.rst
@@ -107,16 +107,16 @@ to another method for centralized error handling.
    end block;
 
 If you need to set a lot of options, you can pass them to the
-:macro:`with-curl-easy` with less verbosity.
+:drm:`make` method with less verbosity.
 
 .. code-block:: dylan
 
    block ()
-     with-curl-easy (curl = make(<curl-easy>),
-                     url = "https://example.org",
-                     ssl-verifypeer = #f,
-                     ssl-verifyhost = 1,
-                     ca-cache-timeout = 604800)
+     with-curl-easy (curl = make(<curl-easy>,
+                                 url: "https://example.org",
+                                 ssl-verifypeer: #f,
+                                 ssl-verifyhost: 1,
+                                 ca-cache-timeout: 604800))
        // perform request
        // gather information
      end with-curl-easy;
@@ -148,7 +148,7 @@ In Opendylan :func:`curl-perform` raises a
 .. code-block:: dylan
    :caption: Dylan example
 
-   block () 
+   block ()
      curl-easy-perform(curl);
      format-out("Request completed successfully.\n")
    exception (err :: <curl-perform-error>)
@@ -190,8 +190,8 @@ wrapper, you access the information directly using property syntax.
    :caption: Dylan Example
 
    block ()
-      with-curl-easy (curl = make(<curl>),
-                      url = "https://example.com/")
+      with-curl-easy (curl = make(<curl>,
+                                  url: "https://example.com/"))
         curl-easy-perform(curl);
         format-out("Time: %d", curl.total-time)
       end;
@@ -250,8 +250,8 @@ The above example could be translated to Opendylan in three ways:
    :caption: Using `add-header!`
 
    with-curl-global($curl-global-default)
-     with-curl-easy(curl = make(<curl-easy>),
-                    url = "https://api.example.com/data")
+     with-curl-easy(curl = make(<curl-easy>,
+                                url: "https://api.example.com/data"))
 
        add-header!(curl,
                    "Content-Type: application/json",
@@ -265,17 +265,17 @@ The above example could be translated to Opendylan in three ways:
        end with-curl-easy;
    end with-curl-global;
 
-Or passing the options to :macro:`with-curl-easy`:
+Or passing the options to :drm:`make` method:
 
 .. code-block:: dylan
-   :caption: Using `with-curl-easy` options
+   :caption: Using `make` keywords
 
    with-curl-global($curl-global-default)
-     with-curl-easy(curl = make(<curl-easy>),
-                    url = "https://api.example.com/data",
-                    header = "Content-Type: application/json",
-                    header = "Authorization: Bearer your_token_here",
-                    header = "X-Custom-Header: Custom Value")
+     with-curl-easy(curl = make(<curl-easy>,
+                                url: "https://api.example.com/data",
+                                header: "Content-Type: application/json",
+                                header: "Authorization: Bearer your_token_here",
+                                header: "X-Custom-Header: Custom Value"))
 
        // ... other curl options ...
 
@@ -290,8 +290,8 @@ Or using the setter method :meth:`curl-header-setter`
    :caption: Using `curl-header-setter`
 
    with-curl-global($curl-global-default)
-     with-curl-easy(curl = make(<curl-easy>),
-                           url = "https://api.example.com/data")
+     with-curl-easy(curl = make(<curl-easy>,
+                                url: "https://api.example.com/data"))
 
        curl.curl-header := "Content-Type: application/json";
        curl.curl-header := "Authorization: Bearer your_token_here";

--- a/src/curl-easy.dylan
+++ b/src/curl-easy.dylan
@@ -589,9 +589,14 @@ define class <curl-info-error> (<curl-error>) end;
 
 ///////////////////////////////////////////////////////////////////////////////
 //
-// Curlerrors as exceptions
+// <curl> and <curl-easy> classes
 //
 ///////////////////////////////////////////////////////////////////////////////
+
+//
+// *curl-options* is a table from keywords to setter methods.  Used to
+// initialize the class in the `make` method.
+//
 
 define variable *curl-options*
   = make(<table>);
@@ -607,13 +612,18 @@ end;
 
 define method make
     (class == <curl-easy>, #rest options, #key) => (_ :: <curl-easy>)
+
+  // Assign slot default initialization or value passed with headers:
   let curl = next-method();
 
+  // check that slot has been initialized
   if (null-pointer?(curl.curl-handle))
     signal(make(<curl-init-error>))
   end;
 
-  // initialize options
+  // initialize curl's options using setters.
+  // parameter options contains pairs of keywords and values
+  // (e.g. #"url", "http://example.com", #"verbose", #t ...)
   for (i from 0 below options.size - 1 by 2)
     let keyword = options[i];
     let value = options[i + 1];

--- a/tests/test-chkspeed.dylan
+++ b/tests/test-chkspeed.dylan
@@ -2,62 +2,79 @@ Module:     curl-easy-test-suite
 Author:     Fernando Raya
 Copyright:  Copyright (C) 2025, Dylan Hackers. All rights reserved.
 License:    See License.txt in this distribution for details.
-Reference:  https://curl.se/libcurl/c/chkspeed.html   
+Reference:  https://curl.se/libcurl/c/chkspeed.html
+Reference:  https://curl.se/libcurl/c/CURLOPT_WRITEFUNCTION.html
+Reference:  https://curl.se/libcurl/c/CURLOPT_XFERINFOFUNCTION.html
+Reference:  https://curl.se/libcurl/c/CURLOPT_NOPROGRESS.html
 
 define test test-chkspeed (tags: #("io", "slow"))
   local method handle-download(ptr, size, nmemb, userdata)
-	  let stream = import-c-dylan-object(userdata);
-	  let bytes = size * nmemb;
-	  write(stream, ptr, end: bytes);
-	  bytes
-	end,
-	method progress-callback(clientp, dltotal, dlnow, ultotal, ulnow)
-	  if (dltotal > 0)
-	    format-out("\rDownloading %d of %d bytes", dlnow, dltotal);
-	    force-out();
-	  end;
-	  0
-	end;
-  let url = "http://ipv4.download.thinkbroadband.com";
+          let stream = import-c-dylan-object(userdata);
+          let bytes = size * nmemb;
+          write(stream, ptr, end: bytes);
+          bytes
+        end,
+        method progress-callback(clientp, dltotal, dlnow, ultotal, ulnow)
+          if (dltotal > 0)
+            format-out("\rDownloading %d of %d bytes", dlnow, dltotal);
+            force-out();
+          end;
+          0
+        end,
+        method curl-easy-handler(url)
+          make(<curl-easy>,
+               url: url,
+               useragent: "dylan-curl-speedchecker/1.0",
+               writefunction: $curl-write-callback,
+               xferinfofunction: $curl-progress-callback,
+               noprogress: #f)
+        end,
+        method print-download-stats(curl)
+          format-out("\n---\n");
+          force-out();
+          assert-true(curl.curl-size-download-t > 0);
+          if (curl.curl-size-download-t > 0)
+            format-out("Data downloaded: %= bytes.\n",
+                       curl.curl-size-download-t)
+          end;
+          assert-true(curl.curl-total-time > 0);
+          if (curl.curl-total-time-t > 0)
+            format-out("Total download time: %= sec.\n",
+                       curl.curl-total-time-t / 1000000.0);
+          end;
+          assert-true(curl.curl-speed-download-t > 0);
+          if (curl.curl-speed-download-t > 0)
+            format-out("Average download speed: %= KB/sec.\n",
+                       curl.curl-speed-download-t / 1000.0);
+          end;
+          assert-true(curl.curl-connect-time-t > 0);
+          if (curl.curl-connect-time-t > 0)
+            format-out("Connect time: %= sec.\n",
+                       curl.curl-connect-time-t / 1000000.0);
+          end;
+        end method;
+
   let filename = "5MB.zip";
+  let url-base = "http://ipv4.download.thinkbroadband.com";
+  let url = concatenate(url-base, "/", filename);
+
   block () 
     with-curl-global ($curl-global-default)
-      with-curl-easy (curl = make(<curl-easy>,
-                                  url: concatenate(url, "/", filename),
-                                  useragent: "dylan-curl-speedchecker/1.0",
-                                  writefunction: $curl-write-callback,
-                                  xferinfofunction: $curl-progress-callback,
-                                  noprogress: #f))
-	      with-open-file (stream = filename, direction: #"output", if-exists: #"replace")
-	        dynamic-bind(*curl-write-callback* = handle-download)
-	          dynamic-bind(*curl-progress-callback* = progress-callback)
-	            register-c-dylan-object(stream);
+      with-curl-easy (curl = curl-easy-handler(url))
+        with-open-file (stream = filename, direction: #"output", if-exists: #"replace")
+          dynamic-bind(*curl-write-callback* = handle-download)
+            dynamic-bind(*curl-progress-callback* = progress-callback)
+              register-c-dylan-object(stream);
               curl.curl-writedata := export-c-dylan-object(stream);
               curl-easy-perform(curl);
               unregister-c-dylan-object(stream);
             end dynamic-bind;
           end dynamic-bind;
         end with-open-file;
-        format-out("\n---\n"); force-out();
-        assert-true(curl.curl-size-download-t > 0);
-        if (curl.curl-size-download-t > 0)
-          format-out("Data downloaded: %= bytes.\n", curl.curl-size-download-t)
-        end;
-        assert-true(curl.curl-total-time > 0);
-        if (curl.curl-total-time-t > 0)
-          format-out("Total download time: %= sec.\n", curl.curl-total-time-t / 1000000.0);
-        end;
-        assert-true(curl.curl-speed-download-t > 0);
-        if (curl.curl-speed-download-t > 0)
-          format-out("Average download speed: %= KB/sec.\n", curl.curl-speed-download-t / 1000.0);
-        end;
-        assert-true(curl.curl-connect-time-t > 0);
-        if (curl.curl-connect-time-t > 0)
-          format-out("Connect time: %= sec.\n", curl.curl-connect-time-t / 1000000.0);
-        end;
+        print-download-stats(curl);
         assert-true(#t);
       end with-curl-easy;
-     end with-curl-global;
+    end with-curl-global;
   exception (err :: <curl-error>)
     format-err("Error while fetching '%s' : %s\n", url, err.curl-error-message);
     assert-true(#f, "An error happend checking download speed test")

--- a/tests/test-chkspeed.dylan
+++ b/tests/test-chkspeed.dylan
@@ -22,12 +22,12 @@ define test test-chkspeed (tags: #("io", "slow"))
   let filename = "5MB.zip";
   block () 
     with-curl-global ($curl-global-default)
-      with-curl-easy (curl = make(<curl-easy>),
-	                    url = concatenate(url, "/", filename),
-	                    useragent = "dylan-curl-speedchecker/1.0",
-	                    writefunction = $curl-write-callback,
-	                    xferinfofunction = $curl-progress-callback,
-	                    noprogress = #f)
+      with-curl-easy (curl = make(<curl-easy>,
+                                  url: concatenate(url, "/", filename),
+                                  useragent: "dylan-curl-speedchecker/1.0",
+                                  writefunction: $curl-write-callback,
+                                  xferinfofunction: $curl-progress-callback,
+                                  noprogress: #f))
 	      with-open-file (stream = filename, direction: #"output", if-exists: #"replace")
 	        dynamic-bind(*curl-write-callback* = handle-download)
 	          dynamic-bind(*curl-progress-callback* = progress-callback)

--- a/tests/test-debug-callback.dylan
+++ b/tests/test-debug-callback.dylan
@@ -36,10 +36,10 @@ end function;
 define test test-debug-callback (tags: #("io"))
   block ()
     with-curl-global ($curl-global-default)
-      with-curl-easy (curl = make(<curl-easy>),
-	                    url = "https://example.com/",
-	                    verbose = #t,  // verbose to use debug-callback
-	                    debugfunction = $curl-debug-callback)
+      with-curl-easy (curl = make(<curl-easy>,
+                                  url: "https://example.com/",
+                                  verbose: #t,  // verbose to use debug-callback
+                                  debugfunction: $curl-debug-callback))
         dynamic-bind (*curl-debug-callback* = dump-debug-callback)
 	        curl-easy-perform(curl);
         end dynamic-bind;

--- a/tests/test-debug-callback.dylan
+++ b/tests/test-debug-callback.dylan
@@ -1,6 +1,8 @@
 Module:    curl-easy-test-suite
 Author:    Fernando Raya
 Copyright: Copyright (C) 2025, Dylan Hackers. All rights reserved.
+Reference: https://curl.se/libcurl/c/CURLOPT_DEBUGFUNCTION.html
+Reference: https://curl.se/libcurl/c/CURLOPT_VERBOSE.html
 
 define function dump-debug-callback
     (handle :: <c-void*>,
@@ -10,38 +12,50 @@ define function dump-debug-callback
      clientp :: <c-void*>)
  => (code :: <integer>)
   local method dump(message, data)
-          format-out("\n%s\n%s", message, data)
-        end method;
-  select (type)
-    $curlinfo-text
-      => dump("<= Recv data", data);
-    $curlinfo-header-in
-      => dump("=> Send data", data);
-    $curlinfo-header-out
-      => dump("=> Send header", data);
-    $curlinfo-data-in
-      => dump("<= Recv header", data);
-    $curlinfo-data-out
-      => dump("=> Send header", data);
-    $curlinfo-ssl-data-in
-      => dump("<= Recv SSL data", data);
-    $curlinfo-ssl-data-out
-      => dump("=> Send SSL data", data);
-    otherwise
-      => format-out("Invalid curl info type: %d", type);
-  end select;
+          format-out("%s\n%s", message, data);
+          force-out();
+        end,
+        method send(what, data)
+          dump(concatenate(">> SEND ", what), data)
+        end,
+        method recv(what, data)
+          dump(concatenate("<< RECV ", what), data)
+        end;
+  let transmit = select (type)
+                   $curlinfo-text
+                     => curry(recv, "data");
+                   $curlinfo-header-in
+                     => curry(send, "data");
+                   $curlinfo-header-out
+                     => curry(send, "header");
+                   $curlinfo-data-in
+                     => curry(recv, "header");
+                   $curlinfo-data-out
+                     => curry(send, "header");
+                   $curlinfo-ssl-data-in
+                     => curry(recv, "SSL data");
+                   $curlinfo-ssl-data-out
+                     => curry(send, "SSL data");
+                   otherwise
+                     => error("Invalid curl info type: %d", type);
+                 end select;
+  transmit(data);
   0
 end function;
 
 define test test-debug-callback (tags: #("io"))
+  local method curl-easy-handle()
+          make(<curl-easy>,
+               url: "https://example.com/",
+               verbose: #t,  // verbose to use debug-callback
+               debugfunction: $curl-debug-callback)
+        end;
+
   block ()
     with-curl-global ($curl-global-default)
-      with-curl-easy (curl = make(<curl-easy>,
-                                  url: "https://example.com/",
-                                  verbose: #t,  // verbose to use debug-callback
-                                  debugfunction: $curl-debug-callback))
+      with-curl-easy (curl = curl-easy-handle())
         dynamic-bind (*curl-debug-callback* = dump-debug-callback)
-	        curl-easy-perform(curl);
+          curl-easy-perform(curl);
         end dynamic-bind;
         assert-true(#t);
       end with-curl-easy;

--- a/tests/test-escape-unescape.dylan
+++ b/tests/test-escape-unescape.dylan
@@ -1,6 +1,8 @@
 Module:    curl-easy-test-suite
 Author:    Fernando Raya
 Copyright: Copyright (C) 2025, Dylan Hackers. All rights reserved.
+Reference: https://curl.se/libcurl/c/curl_escape.html
+Reference: https://curl.se/libcurl/c/curl_unescape.html
 
 define test test-curl-easy-escape ()
   with-curl-global ($curl-global-default)

--- a/tests/test-get-simple-http-page.dylan
+++ b/tests/test-get-simple-http-page.dylan
@@ -5,14 +5,17 @@ Copyright: Copyright (C) 2025, Dylan Hackers. All rights reserved.
 // Example translated from: https://curl.se/libcurl/c/simple.html
 
 define test test-get-simple-http-page (tags: #("io"))
+  local method curl-easy-handler()
+          make(<curl-easy>,
+               url: "http://example.com",
+               followlocation: 1)
+        end;
+
   block ()
     with-curl-global ($curl-global-default)
-      with-curl-easy (curl = make(<curl-easy>,
-                                  url: "http://example.com",
-                                  followlocation: 1))
-	      curl-easy-perform(curl);
-	      assert-true(#t);
-        
+      with-curl-easy (curl = curl-easy-handler())
+        curl-easy-perform(curl);
+        assert-true(#t);
       end with-curl-easy;
     end with-curl-global;
   exception (err :: <curl-error>)

--- a/tests/test-get-simple-http-page.dylan
+++ b/tests/test-get-simple-http-page.dylan
@@ -7,11 +7,12 @@ Copyright: Copyright (C) 2025, Dylan Hackers. All rights reserved.
 define test test-get-simple-http-page (tags: #("io"))
   block ()
     with-curl-global ($curl-global-default)
-      with-curl-easy (curl = make(<curl-easy>),
-                      url = "https://example.com",
-                      followlocation = 1)
+      with-curl-easy (curl = make(<curl-easy>,
+                                  url: "http://example.com",
+                                  followlocation: 1))
 	      curl-easy-perform(curl);
 	      assert-true(#t);
+        
       end with-curl-easy;
     end with-curl-global;
   exception (err :: <curl-error>)

--- a/tests/test-getinfo-cainfo.dylan
+++ b/tests/test-getinfo-cainfo.dylan
@@ -5,8 +5,8 @@ Copyright: Copyright (C) 2025, Dylan Hackers. All rights reserved.
 define test test-getinfo-cainfo () 
   block ()
     with-curl-global ($curl-global-default)
-      with-curl-easy (curl = make(<curl-easy>),
-                      cainfo = "/etc/ssl/certs/SecureTrust_CA.pem")
+      with-curl-easy (curl = make(<curl-easy>,
+                                  cainfo: "/etc/ssl/certs/SecureTrust_CA.pem"))
 	      let cainfo = curl.curl-cainfo;
 	      format-out("default ca info path: '%s'\n", cainfo);
 	      assert-true(#t);

--- a/tests/test-getinfo-cainfo.dylan
+++ b/tests/test-getinfo-cainfo.dylan
@@ -2,14 +2,18 @@ Module:    curl-easy-test-suite
 Author:    Fernando Raya
 Copyright: Copyright (C) 2025, Dylan Hackers. All rights reserved.
 
-define test test-getinfo-cainfo () 
-  block ()
+define test test-getinfo-cainfo ()
+  local method curl-easy-handler()
+          make(<curl-easy>,
+               cainfo: "/etc/ssl/certs/SecureTrust_CA.pem")
+        end;
+
+  block()
     with-curl-global ($curl-global-default)
-      with-curl-easy (curl = make(<curl-easy>,
-                                  cainfo: "/etc/ssl/certs/SecureTrust_CA.pem"))
-	      let cainfo = curl.curl-cainfo;
-	      format-out("default ca info path: '%s'\n", cainfo);
-	      assert-true(#t);
+      with-curl-easy (curl = curl-easy-handler())
+        let cainfo = curl.curl-cainfo;
+        format-out("default ca info path: '%s'\n", cainfo);
+        assert-true(#t);
       end with-curl-easy;
     end with-curl-global;
   exception (err :: <curl-error>)

--- a/tests/test-global.dylan
+++ b/tests/test-global.dylan
@@ -1,6 +1,10 @@
 Module:    curl-easy-test-suite
-Copyright: Copyright (C) 2024, Dylan Hackers. All rights reserved.
+Copyright: Copyright (C) 2025, Dylan Hackers. All rights reserved.
 License:   See License.txt in this distribution for details.
+Comments:  Test performed to check the double initialization of the
+           library.
+Todo:      It is still possible to use the library when the resources have
+           been released.
 
 define test test-global-initialization ()
   assert-false(curl-library-initialized?());

--- a/tests/test-httpbin.dylan
+++ b/tests/test-httpbin.dylan
@@ -16,9 +16,13 @@ define function httpbin
 end;
 
 define test test-postfields (tags: #("io"))
-  with-curl-easy (curl = make(<curl-easy>,
-                              url: httpbin("/post"),
-                              postfields: "name=daniel&project=curl"))
+  local method curl-easy-handler()
+          make(<curl-easy>,
+               url: httpbin("/post"),
+               postfields: "name=daniel&project=curl")
+        end;
+
+  with-curl-easy (curl = curl-easy-handler())
     curl-easy-perform(curl);
     assert-equal(200, curl.curl-response-code);
   end with-curl-easy;
@@ -37,31 +41,43 @@ define test test-http-methods (tags: #("io", "httpbin"))
 end test;
 
 define test test-auth-basic (tags: #("io", "httpbin"))
-  with-curl-easy (curl = make(<curl-easy>,
-                              url: httpbin("/basic-auth/admin/hunter42"),
-                              username: "admin",
-                              password: "hunter42"))
+  local method curl-easy-handler()
+          make(<curl-easy>,
+               url: httpbin("/basic-auth/admin/hunter42"),
+               username: "admin",
+               password: "hunter42")
+        end;
+
+  with-curl-easy (curl = curl-easy-handler())
     curl.curl-easy-perform;
     assert-equal(200, curl.curl-response-code);
   end with-curl-easy;
 end test;
 
 define test test-auth-bearer (tags: #("io", "httpbin"))
+  local method curl-easy-handler(bearer)
+          make(<curl-easy>,
+               url: httpbin("/bearer"),
+               header: concatenate("Authorization: Bearer ", bearer))
+        end;
+
   let bearer = "hunter42";
-  with-curl-easy (curl = make(<curl-easy>,
-                              url: httpbin("/bearer"),
-                              header: concatenate("Authorization: Bearer ", bearer)))
+  with-curl-easy (curl = curl-easy-handler(bearer))
     curl-easy-perform(curl);
     assert-equal(200, curl.curl-response-code);
   end with-curl-easy;
 end test test-auth-bearer;
 
 define test test-auth-digest (tags: #("io", "httpbin"))
-  with-curl-easy (curl = make(<curl-easy>,
-                              url: httpbin("/digest-auth/auth/user/passwd"),
-                              verbose: #f,
-                              userpwd: "user:passwd",
-                              httpauth: $curlauth-digest))
+  local method curl-easy-handler ()
+          make(<curl-easy>,
+               url: httpbin("/digest-auth/auth/user/passwd"),
+               verbose: #f,
+               userpwd: "user:passwd",
+               httpauth: $curlauth-digest)
+        end;
+
+  with-curl-easy (curl = curl-easy-handler())
     curl-easy-perform(curl);
     assert-equal(200, curl.curl-response-code);
   end with-curl-easy;

--- a/tests/test-httpbin.dylan
+++ b/tests/test-httpbin.dylan
@@ -16,9 +16,9 @@ define function httpbin
 end;
 
 define test test-postfields (tags: #("io"))
-  with-curl-easy (curl = make(<curl-easy>),
-                  url = httpbin("/post"),
-                  postfields = "name=daniel&project=curl")
+  with-curl-easy (curl = make(<curl-easy>,
+                              url: httpbin("/post"),
+                              postfields: "name=daniel&project=curl"))
     curl-easy-perform(curl);
     assert-equal(200, curl.curl-response-code);
   end with-curl-easy;
@@ -37,10 +37,10 @@ define test test-http-methods (tags: #("io", "httpbin"))
 end test;
 
 define test test-auth-basic (tags: #("io", "httpbin"))
-  with-curl-easy (curl = make(<curl-easy>),
-                  url = httpbin("/basic-auth/admin/hunter42"),
-                  username = "admin",
-                  password = "hunter42")
+  with-curl-easy (curl = make(<curl-easy>,
+                              url: httpbin("/basic-auth/admin/hunter42"),
+                              username: "admin",
+                              password: "hunter42"))
     curl.curl-easy-perform;
     assert-equal(200, curl.curl-response-code);
   end with-curl-easy;
@@ -48,21 +48,20 @@ end test;
 
 define test test-auth-bearer (tags: #("io", "httpbin"))
   let bearer = "hunter42";
-  with-curl-easy (curl = make(<curl-easy>),
-                  url = httpbin("/bearer"))
-    curl.curl-header := concatenate("Authorization: Bearer ", bearer);
+  with-curl-easy (curl = make(<curl-easy>,
+                              url: httpbin("/bearer"),
+                              header: concatenate("Authorization: Bearer ", bearer)))
     curl-easy-perform(curl);
     assert-equal(200, curl.curl-response-code);
   end with-curl-easy;
 end test test-auth-bearer;
 
 define test test-auth-digest (tags: #("io", "httpbin"))
-  let url = httpbin("/digest-auth/auth/user/passwd");
-  with-curl-easy (curl = make(<curl-easy>),
-                  url = url,
-                  verbose = #f,
-                  userpwd = "user:passwd",
-                  httpauth = $curlauth-digest)
+  with-curl-easy (curl = make(<curl-easy>,
+                              url: httpbin("/digest-auth/auth/user/passwd"),
+                              verbose: #f,
+                              userpwd: "user:passwd",
+                              httpauth: $curlauth-digest))
     curl-easy-perform(curl);
     assert-equal(200, curl.curl-response-code);
   end with-curl-easy;

--- a/tests/test-https.dylan
+++ b/tests/test-https.dylan
@@ -7,11 +7,11 @@ Reference:  https://curl.se/libcurl/c/https.html
 define test test-https (tags: #("io", "slow"))
   block ()
     with-curl-global ($curl-global-default)
-      with-curl-easy (curl = make(<curl-easy>),
-                      url = "https://example.org",
-                      ssl-verifypeer = #f,
-                      ssl-verifyhost = 1,
-                      ca-cache-timeout = 604800)
+      with-curl-easy (curl = make(<curl-easy>,
+                                  url: "https://example.org",
+                                  ssl-verifypeer: #f,
+                                  ssl-verifyhost: 1,
+                                  ca-cache-timeout: 604800))
         curl-easy-perform(curl);
         assert-true(#t);
       end with-curl-easy;

--- a/tests/test-https.dylan
+++ b/tests/test-https.dylan
@@ -3,20 +3,27 @@ Author:     Fernando Raya
 Copyright:  Copyright (C) 2025, Dylan Hackers. All rights reserved.
 License:    See License.txt in this distribution for details.
 Reference:  https://curl.se/libcurl/c/https.html
+Reference:  https://curl.se/libcurl/c/CURLOPT_SSL_VERIFYPEER.html
+Reference:  https://curl.se/libcurl/c/CURLOPT_SSL_VERIFYHOST.html
+Reference:  https://curl.se/libcurl/c/CURLOPT_CA_CACHE_TIMEOUT.html
 
 define test test-https (tags: #("io", "slow"))
+  local method curl-easy-handler()
+          make(<curl-easy>,
+               url: "https://example.org",
+               ssl-verifypeer: #f,
+               ssl-verifyhost: 1,
+               ca-cache-timeout: 604800)
+        end;
+
   block ()
     with-curl-global ($curl-global-default)
-      with-curl-easy (curl = make(<curl-easy>,
-                                  url: "https://example.org",
-                                  ssl-verifypeer: #f,
-                                  ssl-verifyhost: 1,
-                                  ca-cache-timeout: 604800))
+      with-curl-easy (curl = curl-easy-handler())
         curl-easy-perform(curl);
         assert-true(#t);
       end with-curl-easy;
     end with-curl-global;
   exception (err :: <curl-error>)
-    format-err("Curl error: %s\n", err.curl-error-message)
+      format-err("Curl error: %s\n", err.curl-error-message)
   end block;
 end test;

--- a/tests/test-option-headers.dylan
+++ b/tests/test-option-headers.dylan
@@ -5,12 +5,12 @@ License:    See License.txt in this distribution for details.
 
 define test test-option-headers (tags: #("io", "httpbin"))
   with-curl-global($curl-global-default)
-    with-curl-easy (curl = make(<curl-easy>),
-                    url = httpbin("/headers"),
-                    header = "Content-Type: application/json")
-      curl.curl-header := "Authorization: Bearer your_token_here";
-      curl.curl-header := "X-friend: Foo";
+    with-curl-easy (curl = make(<curl-easy>,
+                                url: httpbin("/headers")))
       add-header!(curl,
+                  "Content-Type: application/json",
+                  "Authorization: Bearer your_token_here",
+                  "X-friend: Foo",
                   "X-Custom-Header: Chucho",
                   "Another-Header: Good");
       curl-easy-perform(curl);


### PR DESCRIPTION
- The macro `with-easy-curl` is only responsible for releasing the resources of the handler. 

- The `make` method in the class `<curl-easy>` accepts curl's options as keywords.