### PR TITLE
package: use latest versions of testworks and sphinx-extensions

### DIFF
--- a/dylan-package.json
+++ b/dylan-package.json
@@ -4,8 +4,8 @@
         "command-line-parser@3.2.2"
     ],
     "dev-dependencies": [
-	"sphinx-extensions@1.0.0",
-	"testworks@3.0"
+	"sphinx-extensions",
+	"testworks"
     ],
     "description": "Curl library wrapper",
     "name": "curl",


### PR DESCRIPTION
Less likely to cause dependency conflicts